### PR TITLE
Set chunked upload media to shared

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -320,6 +320,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
 				conf.getUploadBaseURL() + "media/upload.json",
 				new HttpParameter[] { new HttpParameter("command", CHUNKED_INIT),
 						new HttpParameter("media_type", "video/mp4"), 
+						new HttpParameter("shared", true), 
 						new HttpParameter("media_category", "tweet_video"),
 						new HttpParameter("total_bytes", size) })
 				.asJSONObject());


### PR DESCRIPTION
Hi there, thanks a lot for publishing your changes on maven, as the original repository seems to be abandoned. I am trying to use this lib to integrate the new Twitter DM endpoint, as documented in https://dev.twitter.com/rest/direct-messages/attaching-media but there are a few changes that should be made it seems. First of all setting the `shared` value to `true` and then being able to change the `media_category`, what do you think?